### PR TITLE
feat(todo-img): engineering design for image attachment feature

### DIFF
--- a/openspec/changes/active/todo-img/design.md
+++ b/openspec/changes/active/todo-img/design.md
@@ -1,0 +1,216 @@
+---
+featureId: todo-img
+title: Todo 圖片附加功能 - 工程設計
+author: Engineering
+lastUpdated: 2026-03-10
+---
+
+# Todo 圖片附加功能 - 工程設計文檔
+
+## Architecture Overview
+
+### 模組結構
+```
+src/
+├── types/todo.ts           ← 擴展 Todo 型別，加入 imageId/imagePath
+├── store/todoStore.ts      ← 擴展 store，支援圖片附加/刪除邏輯
+├── middleware/validator.ts ← 新增圖片驗證邏輯（格式、大小）
+├── routes/todos.ts         ← 新增 POST /api/todos/:id/image、DELETE /api/todos/:id/image 等端點
+├── middleware/upload.ts    ← 新建：文件上傳中間件（multer 或自實現）
+└── __tests__/
+    ├── todoStore.test.ts   ← 新增圖片相關 test
+    └── todos.test.ts       ← 新增 API 端點 test
+    └── upload.test.ts      ← 新建：上傳邏輯 test
+
+public/
+└── images/
+    └── todos/              ← 圖片儲存目錄（相對路徑）
+```
+
+### 數據模型擴展
+
+**Todo 類型擴展**:
+```typescript
+interface Todo {
+  id: string;
+  title: string;
+  description?: string;
+  completed: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+  imageId?: string;        // ← 新增：圖片檔案名稱（唯一）
+  imagePath?: string;      // ← 新增：相對路徑（如 '/images/todos/todo-123-abc.jpg'）
+}
+
+interface CreateTodoInput {
+  title: string;
+  description?: string;
+  image?: File;            // ← 前端上傳的圖片
+}
+
+interface UpdateTodoInput {
+  title?: string;
+  description?: string;
+  image?: File | null;     // ← 新圖片或 null 表示刪除
+}
+
+interface ImageValidationError {
+  code: 'INVALID_FORMAT' | 'FILE_TOO_LARGE' | 'UPLOAD_FAILED';
+  message: string;
+}
+```
+
+## 具體技術方案
+
+### 1. 圖片存儲方式
+**決策**: 本地檔案系統存儲
+- 圖片存放於 `public/images/todos/` 目錄
+- 檔名格式: `{todoId}-{timestamp}-{randomStr}.{ext}`
+- 例: `todo-123-1678900000-abc.jpg`
+- 原因: Demo 項目，本地存儲最簡單、無外部依賴
+
+### 2. 圖片驗證
+**支援格式**: JPG、PNG、WebP
+**大小限制**: 5 MB（字節）
+**驗證邏輯** (`src/middleware/validator.ts`):
+- `validateImageFile(file: File): { isValid: boolean; error?: ImageValidationError }`
+- 檢查 MIME type 白名單
+- 檢查檔案大小 ≤ 5MB
+- 檢查副檔名與 MIME type 匹配
+
+### 3. API 端點設計
+
+#### 3.1 建立 Todo（包含圖片）
+```http
+POST /api/todos
+Content-Type: multipart/form-data
+
+body:
+  - title: string (required)
+  - description: string (optional)
+  - image: File (optional, ≤ 5 MB)
+
+response 201:
+  {
+    "id": "...",
+    "title": "...",
+    "imagePath": "/images/todos/todo-123-abc.jpg" // ← 新增
+  }
+
+response 400:
+  { "error": "Invalid image format" }
+  { "error": "File too large" }
+```
+
+#### 3.2 更新 Todo（包含圖片替換）
+```http
+PUT /api/todos/:id
+Content-Type: multipart/form-data
+
+body:
+  - title: string (optional)
+  - description: string (optional)
+  - image: File (optional) ← 新圖片或 null（刪除）
+
+response 200:
+  {
+    "id": "...",
+    "imagePath": "/images/todos/todo-123-def.jpg" // ← 已更換
+  }
+
+response 404:
+  { "error": "Todo not found" }
+```
+
+#### 3.3 刪除 Todo 圖片
+```http
+DELETE /api/todos/:id/image
+
+response 200:
+  { "success": true }
+
+response 404:
+  { "error": "Todo or image not found" }
+```
+
+#### 3.4 獲取 Todo（包含圖片資訊）
+```http
+GET /api/todos/:id
+
+response 200:
+  {
+    "id": "...",
+    "imagePath": "/images/todos/todo-123.jpg" // ← 若有圖片
+  }
+```
+
+### 4. 文件上傳中間件
+**實現方式**: 使用 Node.js 內建 API 解析 multipart/form-data
+- 中間件名: `parseFormData()`
+- 存放於 `src/middleware/upload.ts`
+- 驗證後將檔案存至 `public/images/todos/`
+- 返回檔案相對路徑
+
+### 5. 圖片刪除邏輯
+**觸發時機**:
+1. 使用者點擊「刪除圖片」按鈕（呼叫 DELETE /api/todos/:id/image）
+2. 使用者上傳新圖片時，自動刪除舊圖片
+3. 刪除 todo 時，級聯刪除對應圖片
+
+**實現**:
+- `fs.unlink()` 移除舊檔案
+- 若移除失敗，記錄 warn 但不中止流程
+
+## Validation Strategy
+
+### 圖片驗證規則
+```typescript
+function validateImageFile(file: File | undefined): boolean {
+  if (!file) return true;  // 圖片為可選
+
+  const MAX_SIZE = 5 * 1024 * 1024; // 5 MB
+  const ALLOWED_MIMES = ['image/jpeg', 'image/png', 'image/webp'];
+
+  if (!ALLOWED_MIMES.includes(file.type)) {
+    throw AppError(400, 'Invalid image format. Allowed: JPG, PNG, WebP');
+  }
+  if (file.size > MAX_SIZE) {
+    throw AppError(400, 'File too large. Max size: 5 MB');
+  }
+}
+```
+
+### 整合至現有驗證
+- `validateCreateInput()` 擴展以支援 `image`
+- `validateUpdateInput()` 擴展以支援 `image` 和 `image=null`（刪除）
+- 驗證在路由層進行，異常拋出 AppError
+
+## Error Handling Strategy
+
+遵循現有 AppError 模式：
+
+| 錯誤情況 | HTTP Status | error message |
+|---------|-------------|---------------|
+| 圖片格式不支援 | 400 | "Invalid image format. Allowed: JPG, PNG, WebP" |
+| 檔案過大 | 400 | "File too large. Max size: 5 MB" |
+| 上傳磁碟寫入失敗 | 500 | "Failed to save image" |
+| Todo 不存在 | 404 | "Todo not found" |
+| 刪除檔案失敗 | 500 | "Failed to delete image" |
+
+**特殊情況**:
+- 若檔案已存在於磁碟但資料庫未記錄，自動覆寫
+- 若圖片檔案刪除失敗，記錄 warn 但返回 200（不阻擋使用者）
+- 若上傳中途中斷，臨時檔案在下次啟動時自動清理（可選）
+
+## 前端集成註記
+
+前端應在以下位置展示圖片：
+1. **清單頁面**: 若 `imagePath` 存在，顯示 `<img src={imagePath} alt="..." className="thumb" />`
+2. **詳情頁面**: 若 `imagePath` 存在，顯示完整尺寸圖片，並提供「更換」、「刪除」按鈕
+3. **編輯表單**: 提供檔案選擇器，驗證後顯示預覽
+
+## 未來擴展點
+- 伺服器端自動生成縮圖（搭配 Sharp 或 ImageMagick）
+- 上傳進度報告（WebSocket 或 Server-Sent Events）
+- 雲端存儲（S3、CloudFront）
+- 圖片優化（WebP 轉換、壓縮）

--- a/openspec/changes/active/todo-img/tasks.md
+++ b/openspec/changes/active/todo-img/tasks.md
@@ -1,0 +1,65 @@
+---
+featureId: todo-img
+title: Todo 圖片附加功能 - 任務分解
+lastUpdated: 2026-03-10
+---
+
+# Tasks
+
+## 後端實現
+
+### 1. 數據模型擴展
+- [ ] Modify `src/types/todo.ts` — 添加 `imageId?` 和 `imagePath?` 欄位到 Todo 介面，添加 UpdateTodoInput 型別
+
+### 2. 文件上傳中間件
+- [ ] Create `src/middleware/upload.ts` — 實現 multipart form-data 解析和檔案保存邏輯，支援 JPG/PNG/WebP 格式檢查，返回相對路徑
+
+### 3. 圖片驗證邏輯
+- [ ] Modify `src/middleware/validator.ts` — 添加 `validateImageFile()` 驗證函式（格式、大小限制 5MB），整合到 `validateCreateInput()` 和 `validateUpdateInput()` 中
+
+### 4. Store 層擴展
+- [ ] Modify `src/store/todoStore.ts` —
+  - 擴展 create/update 方法以支援 imageId 和 imagePath
+  - 添加 deleteImage() 私有方法（移除磁碟文件）
+  - 刪除 todo 時自動清理圖片
+
+### 5. API 端點 - 建立 Todo（含圖片）
+- [ ] Modify `src/routes/todos.ts` POST 端點 — 支援 multipart form-data 上傳，呼叫上傳中間件驗證圖片，存儲後返回 imagePath
+
+### 6. API 端點 - 更新 Todo（含圖片替換）
+- [ ] Modify `src/routes/todos.ts` PUT 端點 — 支援圖片替換（刪除舊圖，上傳新圖）和刪除圖片（image=null）
+
+### 7. API 端點 - 刪除圖片
+- [ ] Modify `src/routes/todos.ts` — 添加 DELETE `/api/todos/:id/image` 端點
+
+### 8. 靜態文件服務
+- [ ] Modify Hono 應用設置 — 配置 `public/` 目錄為靜態文件根目錄（確保圖片 URL 可被存取）
+
+## 測試
+
+### 9. Store 層測試
+- [ ] Modify `src/__tests__/todoStore.test.ts` — 添加圖片相關測試
+  - 建立 todo + 圖片
+  - 更新圖片
+  - 刪除圖片
+  - 刪除 todo 時清理圖片
+
+### 10. API 端點測試
+- [ ] Modify `src/__tests__/todos.test.ts` — 添加 API 測試
+  - POST /api/todos 含圖片（happy path）
+  - PUT /api/todos/:id 替換圖片
+  - DELETE /api/todos/:id/image
+  - 上傳超過 5MB 的檔案（error case）
+  - 上傳不支援格式（error case）
+
+### 11. 中間件測試
+- [ ] Create `src/__tests__/upload.test.ts` — 測試檔案上傳中間件
+  - 有效格式上傳
+  - 無效格式拒絕
+  - 檔案過大拒絕
+  - 檔案存儲驗證
+
+## 清理
+
+### 12. 確保目錄存在
+- [ ] 運行時確保 `public/images/todos/` 目錄存在（應用啟動時自動建立）

--- a/src/types/todo.ts
+++ b/src/types/todo.ts
@@ -5,6 +5,8 @@ export interface Todo {
   completed: boolean;
   createdAt: string;
   updatedAt: string;
+  imageId?: string;
+  imagePath?: string;
 }
 
 export interface CreateTodoInput {


### PR DESCRIPTION
## Spec
[Todo 圖片附加功能](openspec/specs/todo-img/spec.md)

## Reason
**feat** — 新功能設計文檔和數據模型擴展

## Spec PR
N/A

## Behavior Diff

### Before
- Todo 只支援標題、描述、完成狀態
- 無圖片相關功能

### After
- 🎨 **擴展 Todo 數據模型**: 添加 `imageId?` 和 `imagePath?` 欄位
- 📋 **工程設計文檔**: 完整的架構設計、API 設計、驗證策略
- 📝 **任務分解**: 12 個細粒度實裝任務（檔案上傳、驗證、端點、測試等）
- 📐 **技術決策**:
  - 本地檔案系統存儲 (`public/images/todos/`)
  - 支援格式: JPG、PNG、WebP（5 MB 限制）
  - 自實現 multipart form-data 中間件
  - 級聯刪除（刪除 todo 自動清理圖片）

## Tests
✅ 所有現有測試通過 (46 passed)
- 本 PR 無新增測試（設計文檔階段，測試在實裝階段添加）

## Implementation Roadmap
以下 12 個任務已分解，待後續實裝：
1. ✅ 數據模型擴展
2. 文件上傳中間件
3. 圖片驗證邏輯
4. Store 層擴展
5-7. API 端點 (建立/更新/刪除)
8. 靜態文件服務配置
9-11. 單元測試 (Store/API/中間件)
12. 目錄初始化

## Closes
Closes #1